### PR TITLE
Add More Modded Items To Light Compatibility

### DIFF
--- a/src/main/resources/data/archipelago/ap_items/single/bottles.json
+++ b/src/main/resources/data/archipelago/ap_items/single/bottles.json
@@ -1,6 +1,12 @@
 {
   "mod": "archipelago",
   "entries": [
-    "minecraft:glass_bottle"
+    "minecraft:glass_bottle",
+    "minecraft:potion",
+    "minecraft:honey_bottle",
+    {
+      "id": "#c:drink_containing/bottle",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/brush.json
+++ b/src/main/resources/data/archipelago/ap_items/single/brush.json
@@ -1,6 +1,10 @@
 {
   "mod": "archipelago",
   "entries": [
-    "minecraft:brush"
+    "minecraft:brush",
+    {
+      "id": "#c:tools/brush",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/bucket.json
+++ b/src/main/resources/data/archipelago/ap_items/single/bucket.json
@@ -1,6 +1,20 @@
 {
   "mod": "archipelago",
   "entries": [
-    "minecraft:bucket"
+    "minecraft:bucket",
+    "minecraft:water_bucket",
+    "minecraft:lava_bucket",
+    "minecraft:milk_bucket",
+    "minecraft:powder_snow_bucket",
+    "minecraft:axolotl_bucket",
+    "minecraft:cod_bucket",
+    "minecraft:salmon_bucket",
+    "minecraft:pufferfish_bucket",
+    "minecraft:tadpole_bucket",
+    "minecraft:tropical_fish_bucket",
+    {
+      "id": "#c:buckets",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/chests.json
+++ b/src/main/resources/data/archipelago/ap_items/single/chests.json
@@ -5,6 +5,10 @@
     "minecraft:trapped_chest",
     "minecraft:chest_minecart",
     "minecraft:barrel",
-    "#minecraft:chest_boats"
+    "#minecraft:chest_boats",
+    {
+      "id": "#c:chests",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/chests.json
+++ b/src/main/resources/data/archipelago/ap_items/single/chests.json
@@ -5,6 +5,7 @@
     "minecraft:trapped_chest",
     "minecraft:chest_minecart",
     "minecraft:barrel",
+    "minecraft:ender_chest",
     "#minecraft:chest_boats",
     {
       "id": "#c:chests",

--- a/src/main/resources/data/archipelago/ap_items/single/fishing.json
+++ b/src/main/resources/data/archipelago/ap_items/single/fishing.json
@@ -3,6 +3,10 @@
   "entries": [
     "minecraft:fishing_rod",
     "minecraft:carrot_on_a_stick",
-    "minecraft:warped_fungus_on_a_stick"
+    "minecraft:warped_fungus_on_a_stick",
+    {
+      "id": "#c:tools/fishing_rods",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/igniter.json
+++ b/src/main/resources/data/archipelago/ap_items/single/igniter.json
@@ -1,6 +1,11 @@
 {
   "mod": "archipelago",
   "entries": [
-    "minecraft:flint_and_steel"
+    "minecraft:flint_and_steel",
+    "minecraft:fire_charge",
+    {
+      "id": "#c:tools/igniter",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/minecarts.json
+++ b/src/main/resources/data/archipelago/ap_items/single/minecarts.json
@@ -6,6 +6,10 @@
     "minecraft:chest_minecart",
     "minecraft:furnace_minecart",
     "minecraft:tnt_minecart",
-    "#minecraft:rails"
+    "#minecraft:rails",
+    {
+      "id": "#c:minecarts",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/shears.json
+++ b/src/main/resources/data/archipelago/ap_items/single/shears.json
@@ -1,6 +1,10 @@
 {
   "mod": "archipelago",
   "entries": [
-    "minecraft:shears"
+    "minecraft:shears",
+    {
+      "id": "#c:shears",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/archipelago/ap_items/single/shield.json
+++ b/src/main/resources/data/archipelago/ap_items/single/shield.json
@@ -1,6 +1,10 @@
 {
   "mod": "archipelago",
   "entries": [
-    "minecraft:shield"
+    "minecraft:shield",
+    {
+      "id": "#c:shields",
+      "required": false
+    }
   ]
 }


### PR DESCRIPTION
This pull request, uh, adds "light compatibility" (as in, no logic changes, but still restriction) to a few modded items through tags, as well as changes a few things like adding Ender Chests to being locked.

...may need some slight logic modifications for the vanilla items added to the restricted stuff.